### PR TITLE
Remove ambigous rule

### DIFF
--- a/Rules
+++ b/Rules
@@ -13,7 +13,6 @@ Rule 4: Follow Reddit TOS
 -No sexualizing minors.
 -No brigading or harassing
 -No animemes “war” posts
--No hate speech
 
 Rule 5: No reposts
 Refrain from reposting a meme that has been on this subreddit before.


### PR DESCRIPTION
As also pointed out by [this comment tree](https://www.reddit.com/r/goodanimemes/comments/ijfdzx/vote_about_the_rules/g3dat8l/?utm_source=reddit&utm_medium=web2x&context=3), this phrasing can lead to the repetition of the previous events (of the phrase being abused) and should be removed from the rules.  
On top of that it does not fit the rule it is placed under [Reddit TOS](https://www.redditinc.com/policies/content-policy) does not use this phrasing but says that actions [sic] _that incite violence or that promote hate based on identity or vulnerability_ are bannable, not "hate speech"